### PR TITLE
Fixed generation of references according to 'baseurl' property.

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,7 +10,7 @@
     
 
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
-    <link rel="icon" type="image/png" href="/images/lambda-xl.png">
+    <link rel="icon" type="image/png" href="{{ "/images/lambda-xl.png" | prepend: site.baseurl }}">
 
     <!-- Custom CSS -->
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,600,700' rel='stylesheet' type='text/css'>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,22 +1,22 @@
 <header id="main-header">
   <div id="site-title">
-    <a href="/">{{ site.title }}</a>
+    <a href="{{ site.baseurl }}/">{{ site.title }}</a>
   </div>
   <div class="links">
   {% assign current = page.title %}
-  <a href="/" class="page-link{% if current == null %} active{% endif %}">Blog</a>
+  <a href="{{ site.baseurl }}/" class="page-link{% if current == null %} active{% endif %}">Blog</a>
   {% for page in site.pages %}
     {% if page.title and page.permalink != "/404.html" %}
       <a class="page-link{% if current == page.title %} active{% endif %}"
         href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>
     {% endif %}
   {% endfor %}
-  <a href="/feed.xml" target="_blank" class="page-link">RSS</a>
+  <a href="{{ "/feed.xml" | prepend: site.baseurl }}" target="_blank" class="page-link">RSS</a>
   {% if site.github_repo %}
   <a href="http://github.com/{{ site.github_repo }}"
     target="_blank"
     class="page-link github-link">
-    <img src="/images/github-repo.png" alt="Github Repository">
+    <img src="{{ "/images/github-repo.png" | prepend: site.baseurl }}" alt="Github Repository">
     Source</a>
   {% endif %}
   </div>

--- a/_includes/post.html
+++ b/_includes/post.html
@@ -3,7 +3,7 @@
 	<div class="entry-content">
 
 	  <header>
-	    <h1 class="entry-title"><a href="{{ page.url }}">{{ page.title }}</a></h1>
+	    <h1 class="entry-title"><a href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a></h1>
 	    <p class="entry-meta">
 		    {{ page.date | date: "%b %-d, %Y" }}
 		    {% if page.category %} • Category: {{ page.category|capitalize }}{% endif %}
@@ -16,7 +16,7 @@
   		{% else %}
 	  		{{ page.excerpt }}
 	  		{% if page.content contains '<!-- more -->' %}
-	  		<p><a href="{{ page.url }}">Read more »</a></p>
+	  		<p><a href="{{ page.url | prepend: site.baseurl }}">Read more »</a></p>
 	  		{% endif %}
   		{% endif %}
 	  </article>


### PR DESCRIPTION
When baseurl property in the _config.yml is not default (for example, '/blog'), some references are not valid.
